### PR TITLE
Fix: Reset game state when switching to a different player

### DIFF
--- a/src/components/Player/PlayerLogin.tsx
+++ b/src/components/Player/PlayerLogin.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Card } from '../UI/Card';
 import { Button } from '../UI/Button';
 import { usePlayerStore } from '../../store/playerStore';
+import { useGameStore } from '../../store/gameStore';
 import { PlayerProfile } from './PlayerProfile';
 
 interface PlayerFormData {
@@ -16,6 +17,7 @@ interface PlayerLoginProps {
 
 export const PlayerLogin = ({ onPlayerSelected }: PlayerLoginProps = {}) => {
   const { players, createPlayer, selectPlayer, currentPlayer } = usePlayerStore();
+  const { currentGame, resetGame } = useGameStore();
   const [isCreating, setIsCreating] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
 
@@ -34,6 +36,13 @@ export const PlayerLogin = ({ onPlayerSelected }: PlayerLoginProps = {}) => {
   };
 
   const handleSelectPlayer = (playerId: string) => {
+    // Check if we're switching to a different player
+    // Since currentPlayer might be null when switching, check the game's playerId
+    if (currentGame && currentGame.playerId !== playerId) {
+      // Reset the game state if switching to a different player
+      resetGame();
+    }
+
     selectPlayer(playerId);
     onPlayerSelected?.();
   };


### PR DESCRIPTION
## Summary
- Fixed issue where switching between players would show the previous player's game state
- Game state is now properly reset when switching to a different player
- Game state is preserved when re-selecting the same player (edge case)

## Changes Made
- Modified `PlayerLogin` component to check if the selected player differs from the game's current player
- When switching to a different player, the game state is reset
- When selecting the same player (e.g., Bob → Bob), the game continues where it left off

## Test Plan
✅ Tested with Playwright:
1. Start a game as Bob, make a guess
2. Switch to Alice - verify game is reset
3. Switch back to Bob - verify game is reset

✅ Tested edge case:
1. Start a game as Bob, make a guess
2. Click switch, then select Bob again
3. Verify game state is preserved with guess history intact

This improves the user experience by preventing players from seeing each other's games while allowing them to continue their game if they accidentally click the switch button.

🤖 Generated with [Claude Code](https://claude.ai/code)