### PR TITLE
Remove Give up and New Game buttons from game interface

### DIFF
--- a/src/components/Game/GameBoard.tsx
+++ b/src/components/Game/GameBoard.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Card } from '../UI/Card';
 import { Button } from '../UI/Button';
-import { Modal } from '../UI/Modal';
 import { GuessInput } from './GuessInput';
 import { GuessHistory } from './GuessHistory';
 import { GameStats } from './GameStats';
@@ -17,7 +16,6 @@ export const GameBoard = () => {
 
   const { currentPlayer, updatePlayerStats } = usePlayerStore();
   const [activeTab, setActiveTab] = useState<RightPanelTab>('history');
-  const [showGiveUpModal, setShowGiveUpModal] = useState(false);
 
   // Update player stats when game is won
   useEffect(() => {
@@ -80,28 +78,8 @@ export const GameBoard = () => {
 
         <GameStats />
 
-        <div className="mt-8 space-y-4">
+        <div className="mt-8">
           <GuessInput />
-
-          {/* Game Control Buttons - only show during active play */}
-          {gameStatus === 'playing' && guesses.length > 0 && (
-            <div className="flex gap-3 justify-center">
-              <Button onClick={() => setShowGiveUpModal(true)} variant="secondary" size="sm">
-                Give Up
-              </Button>
-              <Button
-                onClick={() => {
-                  if (window.confirm('Are you sure you want to start a new game?')) {
-                    handleNewGame();
-                  }
-                }}
-                variant="secondary"
-                size="sm"
-              >
-                New Game
-              </Button>
-            </div>
-          )}
         </div>
 
         <AnimatePresence>
@@ -197,35 +175,6 @@ export const GameBoard = () => {
           </AnimatePresence>
         </div>
       </div>
-
-      {/* Give Up Modal */}
-      <Modal
-        isOpen={showGiveUpModal}
-        onClose={() => setShowGiveUpModal(false)}
-        title="Give Up?"
-        actions={[
-          {
-            label: 'Cancel',
-            onClick: () => setShowGiveUpModal(false),
-            variant: 'secondary',
-          },
-          {
-            label: 'Give Up',
-            onClick: () => {
-              setShowGiveUpModal(false);
-              resetGame();
-            },
-            variant: 'primary',
-          },
-        ]}
-      >
-        <p className="mb-4">Are you sure you want to give up?</p>
-        {currentGame && (
-          <p className="text-lg font-semibold text-purple-400">
-            The number was: {currentGame.targetNumber}
-          </p>
-        )}
-      </Modal>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Removed "Give up" and "New Game" buttons that appeared below the number input during gameplay
- Removed the Give up modal and associated state management
- Cleaned up unused imports and state variables
- Updated integration tests to reflect the new game behavior

## Changes
1. **Removed buttons section** from GameBoard component that displayed "Give up" and "New Game" controls
2. **Removed Give up modal** that showed the target number when giving up
3. **Removed `showGiveUpModal` state** and Modal import as they're no longer needed
4. **Updated tests** to reflect that games can only be abandoned by switching players

## Rationale
This change simplifies the game interface by removing redundant controls:
- Players can still start a new game after winning using the "Play Again" button
- Games are automatically abandoned when switching to a different player
- The cleaner interface focuses attention on the core gameplay

## Test Plan
✅ Manually tested:
- Started game and verified no buttons appear below input
- Made guesses and confirmed game continues normally
- Won game and used "Play Again" button successfully
- Switched players mid-game and confirmed game resets

✅ All automated tests pass with updated integration test

🤖 Generated with [Claude Code](https://claude.ai/code)